### PR TITLE
feat: Exposes ReaderWriterExtensions::ReadVector3FArray

### DIFF
--- a/src/MeshModel/Mesh.cs
+++ b/src/MeshModel/Mesh.cs
@@ -155,10 +155,10 @@ namespace Zeiss.PiWeb.MeshModel
 			var layer = binaryReader.ReadConditionalStringArray();
 
 			var textureCoordinates = fileVersion >= FileVersion22 && binaryReader.ReadBoolean()
-				? binaryReader.ReadArray( Vector2FIo.Instance )
+				? binaryReader.ReadLengthAndArray( Vector2FIo.Instance )
 				: null;
 			var colors = fileVersion >= FileVersion33 && binaryReader.ReadBoolean()
-				? binaryReader.ReadArray( ColorIo.Instance )
+				? binaryReader.ReadLengthAndArray( ColorIo.Instance )
 				: null;
 
 			return new Mesh( index, positions, normals, indices, textureCoordinates, color, colors, layer, name );

--- a/src/MeshModel/MeshValue.cs
+++ b/src/MeshModel/MeshValue.cs
@@ -53,7 +53,7 @@ namespace Zeiss.PiWeb.MeshModel
 
 		internal static MeshValue Read( BinaryReader binaryReader, Version fileVersion )
 		{
-			return binaryReader.ReadBoolean() ? new MeshValue( binaryReader.ReadArray( FloatIo.Instance ) ) : null;
+			return binaryReader.ReadBoolean() ? new MeshValue( binaryReader.ReadLengthAndArray( FloatIo.Instance ) ) : null;
 		}
 
 		internal void Write( BinaryWriter binaryWriter )

--- a/src/Tests/MeshModel.Tests.csproj
+++ b/src/Tests/MeshModel.Tests.csproj
@@ -15,7 +15,7 @@
     <ItemGroup>
         <ProjectReference Include="..\MeshModel\MeshModel.csproj" />
     </ItemGroup>
-    
+
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.16.0" />
         <PackageReference Include="Moq" Version="4.16.1" />
@@ -35,5 +35,5 @@
     <ItemGroup>
         <Content CopyToOutputDirectory="PreserveNewest" Include="TestData\*.meshModel" />
     </ItemGroup>
-    
+
 </Project>

--- a/src/Tests/ReaderWriterExtensionsTest.cs
+++ b/src/Tests/ReaderWriterExtensionsTest.cs
@@ -49,7 +49,7 @@ namespace Zeiss.PiWeb.MeshModel.Tests
 			using( var stream = new MemoryStream( bytes ) )
 			{
 				using var binaryReader = new BinaryReader( stream );
-				readFloats = binaryReader.ReadArray( FloatIo.Instance );
+				readFloats = binaryReader.ReadLengthAndArray( FloatIo.Instance );
 			}
 
 
@@ -76,7 +76,7 @@ namespace Zeiss.PiWeb.MeshModel.Tests
 			using( var stream = new MemoryStream( bytes ) )
 			{
 				using var binaryReader = new BinaryReader( stream );
-				readVectors = binaryReader.ReadArray( Vector3FIo.Instance );
+				readVectors = binaryReader.ReadLengthAndArray( Vector3FIo.Instance );
 			}
 
 
@@ -103,7 +103,7 @@ namespace Zeiss.PiWeb.MeshModel.Tests
 			using( var stream = new MemoryStream( bytes ) )
 			{
 				using var binaryReader = new BinaryReader( stream );
-				readVectors = binaryReader.ReadArray( Vector2FIo.Instance );
+				readVectors = binaryReader.ReadLengthAndArray( Vector2FIo.Instance );
 			}
 
 
@@ -130,7 +130,7 @@ namespace Zeiss.PiWeb.MeshModel.Tests
 			using( var stream = new MemoryStream( bytes ) )
 			{
 				using var binaryReader = new BinaryReader( stream );
-				readColors = binaryReader.ReadArray( ColorIo.Instance );
+				readColors = binaryReader.ReadLengthAndArray( ColorIo.Instance );
 			}
 
 


### PR DESCRIPTION
Exposes the method `ReaderWriterExtensions::ReadVector3FArray` to allow reading Vector3F arrays from a binary reader.