### PR TITLE
Change assembly name to Zeiss.PiWeb.MeshModel

### DIFF
--- a/src/MeshModel/MeshModel.csproj
+++ b/src/MeshModel/MeshModel.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>8.0</LangVersion>
-        <AssemblyName>PiWeb.MeshModel</AssemblyName>
+        <AssemblyName>Zeiss.PiWeb.MeshModel</AssemblyName>
         <RootNamespace>Zeiss.PiWeb.MeshModel</RootNamespace>
         <Copyright>Copyright © 2020 Carl Zeiss Industrielle Messtechnik GmbH</Copyright>
         <Company>Carl Zeiss Industrielle Messtechnik GmbH</Company>

--- a/src/MeshModel/Properties/AssemblyInfo.cs
+++ b/src/MeshModel/Properties/AssemblyInfo.cs
@@ -4,4 +4,4 @@ using System.Runtime.CompilerServices;
 
 #endregion
 
-[assembly: InternalsVisibleTo( "PiWeb.MeshModel.Tests" )]
+[assembly: InternalsVisibleTo( "Zeiss.PiWeb.MeshModel.Tests" )]

--- a/src/Tests/MeshModel.Tests.csproj
+++ b/src/Tests/MeshModel.Tests.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <LangVersion>8.0</LangVersion>
-        <AssemblyName>PiWeb.MeshModel.Tests</AssemblyName>
+        <AssemblyName>Zeiss.PiWeb.MeshModel.Tests</AssemblyName>
         <RootNamespace>Zeiss.PiWeb.MeshModel.Tests</RootNamespace>
         <Copyright>Copyright © 2020 Carl Zeiss Industrielle Messtechnik GmbH</Copyright>
         <Company>Carl Zeiss Industrielle Messtechnik GmbH</Company>


### PR DESCRIPTION
Necessary change for compatibility reasons in the PiWeb project.