### PR TITLE
refactor: Avoid temporary arrays to reduce allocations

### DIFF
--- a/src/MeshModel/HashBuilder.cs
+++ b/src/MeshModel/HashBuilder.cs
@@ -48,12 +48,6 @@ namespace Zeiss.PiWeb.MeshModel
 			return hashAlgorithm.ComputeHash( stream );
 		}
 
-		internal static byte[] ComputeHash( byte[] buffer )
-		{
-			using var hashAlgorithm = CreateHashAlgorithm();
-			return hashAlgorithm.ComputeHash( buffer );
-		}
-
 		#endregion
 	}
 }

--- a/src/MeshModel/ReaderWriterExtensions.cs
+++ b/src/MeshModel/ReaderWriterExtensions.cs
@@ -86,7 +86,7 @@ namespace Zeiss.PiWeb.MeshModel
 		/// <summary>
 		/// Writes the color value as an integer value.
 		/// </summary>
-		internal static void WriteArgbColor( this BinaryWriter writer, Color color )
+		private static void WriteArgbColor( this BinaryWriter writer, Color color )
 		{
 			writer.Write( color.A << 24 | color.R << 16 | color.G << 8 | color.B );
 		}
@@ -275,26 +275,6 @@ namespace Zeiss.PiWeb.MeshModel
 			return layer;
 		}
 
-		/// <summary>
-		/// Reads the given number of <see cref="Vector3F"/> from a <see cref="BinaryReader"/>.
-		/// </summary>
-		/// <param name="reader">To read binary stream.</param>
-		/// <param name="numberOfElements">To know where to stop reading.</param>
-		/// <returns>Array of vectors.</returns>
-		/// <exception cref="T:System.ArgumentOutOfRangeException">If <paramref name="numberOfElements">numberOfElements</paramref> exceeds the remaining length of the buffer or is &lt; 0.</exception>
-		public static Vector3F[] ReadVector3FArray( this BinaryReader reader, int numberOfElements )
-		{
-			if( numberOfElements < 0
-				|| reader.BaseStream.Length - reader.BaseStream.Position < numberOfElements * Vector3F.Stride )
-			{
-				throw new ArgumentOutOfRangeException(
-					nameof( numberOfElements ),
-					$"The given {nameof( numberOfElements )} is out of the bounds [0,<remaining buffer length / element stride>]." );
-			}
-
-			return reader.ReadArray( Vector3FIo.Instance, numberOfElements );
-		}
-
 		internal static T[] ReadLengthAndArray<T>( this BinaryReader reader, IStructArrayIo<T> structArrayIo )
 			where T : struct
 		{
@@ -303,14 +283,12 @@ namespace Zeiss.PiWeb.MeshModel
 			return reader.ReadArray( structArrayIo, length );
 		}
 
-		internal static T[] ReadArray<T>( this BinaryReader reader, IStructArrayIo<T> structArrayIo, int numberOfElements )
-			where T : struct
+		private static T[] ReadArray<T>( this BinaryReader reader, IStructArrayIo<T> structArrayIo, int numberOfElements ) where T : struct
 		{
 			var result = new T[ numberOfElements ];
 			foreach( var (count, current, buffer) in reader.ReadByteArrays( numberOfElements, structArrayIo.Stride ) )
 			{
 				var index = current / structArrayIo.Stride;
-
 				structArrayIo.ReadBuffer( buffer, result, count, index );
 			}
 

--- a/src/MeshModel/StructArrayIo.cs
+++ b/src/MeshModel/StructArrayIo.cs
@@ -13,14 +13,17 @@ namespace Zeiss.PiWeb.MeshModel
 	#region usings
 
 	using System;
+	using System.IO;
 
 	#endregion
 
-	public interface IStructArrayIo<in T>
-		where T : struct
+	public interface IStructArrayIo<in T> where T : struct
 	{
 		#region properties
 
+		/// <summary>
+		/// Returns the data stride.
+		/// </summary>
 		int Stride { get; }
 
 		#endregion
@@ -42,6 +45,14 @@ namespace Zeiss.PiWeb.MeshModel
 		/// <returns>Position in the source array after filling the buffer.</returns>
 		int WriteBuffer( byte[] buffer, T[] source, int count, int index );
 
+		/// <summary>
+		/// Reads the given buffer array with the given number of elements.
+		/// </summary>
+		/// <seealso cref="WriteBuffer"/>
+		/// <param name="buffer">Buffer to be read.</param>
+		/// <param name="result">Result data array.</param>
+		/// <param name="count">Number of items to take from the source array.</param>
+		/// <param name="index">Where to start copying from the source array.</param>
 		void ReadBuffer( byte[] buffer, T[] result, int count, int index );
 
 		#endregion
@@ -166,12 +177,13 @@ namespace Zeiss.PiWeb.MeshModel
 		/// </remarks>
 		public int WriteBuffer( byte[] buffer, Vector2F[] source, int count, int index )
 		{
-			const int componentSize = sizeof( float );
+			using var stream = new MemoryStream( buffer, true );
+			using var binaryWriter = new BinaryWriter( stream );
 
 			for( var i = 0; i < count; i += Stride, index++ )
 			{
-				Array.Copy( BitConverter.GetBytes( source[ index ].X ), 0, buffer, i, componentSize );
-				Array.Copy( BitConverter.GetBytes( source[ index ].Y ), 0, buffer, i + componentSize, componentSize );
+				binaryWriter.Write( source[ index ].X );
+				binaryWriter.Write( source[ index ].Y );
 			}
 
 			return index;
@@ -219,15 +231,14 @@ namespace Zeiss.PiWeb.MeshModel
 		/// </remarks>
 		public int WriteBuffer( byte[] buffer, Vector3F[] source, int count, int index )
 		{
-			const int componentSize = sizeof( float );
-			const int yOffset = componentSize;
-			const int zOffset = componentSize * 2;
+			using var stream = new MemoryStream( buffer, true );
+			using var binaryWriter = new BinaryWriter( stream );
 
 			for( var i = 0; i < count; i += Stride, index++ )
 			{
-				Array.Copy( BitConverter.GetBytes( source[ index ].X ), 0, buffer, i, componentSize );
-				Array.Copy( BitConverter.GetBytes( source[ index ].Y ), 0, buffer, i + yOffset, componentSize );
-				Array.Copy( BitConverter.GetBytes( source[ index ].Z ), 0, buffer, i + zOffset, componentSize );
+				binaryWriter.Write( source[ index ].X );
+				binaryWriter.Write( source[ index ].Y );
+				binaryWriter.Write( source[ index ].Z );
 			}
 
 			return index;

--- a/src/MeshModel/ZipEntriesGuidGenerator.cs
+++ b/src/MeshModel/ZipEntriesGuidGenerator.cs
@@ -18,6 +18,7 @@ namespace Zeiss.PiWeb.MeshModel
 	using System.IO.Compression;
 	using System.Linq;
 	using System.Reflection;
+	using System.Text;
 
 	#endregion
 
@@ -59,14 +60,18 @@ namespace Zeiss.PiWeb.MeshModel
 		public static Guid GenerateGuidStatic( IEnumerable<ZipArchiveEntry> entries )
 		{
 			var stream = new MemoryStream();
-			foreach( var entry in entries.OrderBy( x => x.FullName, StringComparer.Ordinal ) )
+			using( var binaryWriter = new BinaryWriter( stream, Encoding.UTF8, true ) )
 			{
-				stream.Write( BitConverter.GetBytes( entry.CompressedLength ), 0, 8 );
-				stream.Write( BitConverter.GetBytes( entry.Length ), 0, 8 );
-				stream.Write( BitConverter.GetBytes( GetChecksum( entry ) ), 0, 4 );
+				foreach( var entry in entries.OrderBy( x => x.FullName, StringComparer.Ordinal ) )
+				{
+					binaryWriter.Write( entry.CompressedLength );
+					binaryWriter.Write( entry.Length );
+					binaryWriter.Write( GetChecksum( entry ) );
+				}
 			}
 
 			stream.Position = 0;
+
 			return new Guid( HashBuilder.ComputeHash( stream ) );
 		}
 


### PR DESCRIPTION
* We can use the binary writer to efficiently write the binary representation of integral types into a stream/array
* We avoid allocating a small array for eachs single value